### PR TITLE
Change coin input labels to Coin 1/Coin 2

### DIFF
--- a/releases/Alpine Ski.mra
+++ b/releases/Alpine Ski.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,-,Start,Select,L,R,X,Y" names="Alpine,-,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,-,Start,Select,L,R,X,Y" names="Alpine,-,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,40,FF,00,00,00,00,00">
 		<dip bits="8,9" name="Jump Bonus" ids="2000-4000,1000-2500,800-2000,500-1500"/>
 		<dip bits="11,12" name="Game Time" ids="2:30,2:00,1:30,1:00"/>

--- a/releases/Bio Attack.mra
+++ b/releases/Bio Attack.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,00,FF,00,00,00,00,00">
 		<dip bits="8,9" name="Bonus Life" ids="10000,15000,20000,25000"/>
 		<dip bits="11,12" name="Lives" ids="3,4,5,6"/>

--- a/releases/Elevator Action Bootleg.mra
+++ b/releases/Elevator Action Bootleg.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>Horizontal</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,00,FF,00,00,00,00,00">
 		<dip bits="8,9" name="Bonus Life" ids="10000,15000,20000,25000"/>
 		<dip bits="10" name="Free Play" ids="Off,On"/>

--- a/releases/High Way Race.mra
+++ b/releases/High Way Race.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,40,FF,00,00,00,00,00">
 		<dip bits="10" name="Free Play" ids="Off,On"/>
 		<dip bits="11,12" name="Lives" ids="3,4,5,6"/>

--- a/releases/Jungle King.mra
+++ b/releases/Jungle King.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>horizontal</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,80,FF,00,00,00,00,00">
 		<dip bits="8,9" name="Clearing Bonus" ids="No Bonus,Time X 1,Time X 2,Time X 3"/>
 		<dip bits="11,12" name="Lives" ids="3,4,5,6"/>

--- a/releases/Pirate Pete.mra
+++ b/releases/Pirate Pete.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>Horizontal</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,80,FF,00,00,00,00,00">
 		<dip bits="8,9" name="Clearing Bonus" ids="No Bonus,Time X 1,Time X 2,Time X 3"/>
 		<dip bits="11,12" name="Lives" ids="3,4,5,6"/>

--- a/releases/Space Cruiser.mra
+++ b/releases/Space Cruiser.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,00,FF,00,00,00,00,00">
 		<dip bits="11,12" name="Lives" ids="3,4,5,6"/>
 		<dip bits="14" name="Flip Screen" ids="Off, On"/>

--- a/releases/Space Seeker.mra
+++ b/releases/Space Seeker.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>horizontal</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,00,FF,00,00,00,00,00">
 		<dip bits="11,12" name="Lives" ids="6,5,4,3"/>
 		<dip bits="13" name="Test Mode" ids="Off, On"/>

--- a/releases/Time Tunnel.mra
+++ b/releases/Time Tunnel.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>horizontal</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,C0,FF,00,00,00,00,00">
 		<dip bits="10" name="Free Play" ids="Off,On"/>
 		<dip bits="11,12" name="Lives" ids="3,4,5,6"/>

--- a/releases/Water Ski.mra
+++ b/releases/Water Ski.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,00,FF,00,00,00,00,00">
 		<dip bits="10" name="Free Play" ids="Off,On"/>
 		<dip bits="11,12" name="Game Time" ids="2:30,2:20,2:10,2:00"/>

--- a/releases/Wild Western.mra
+++ b/releases/Wild Western.mra
@@ -10,7 +10,7 @@
 	<rbf>TaitoSJ</rbf>
 	<rotation>vertical (cw)</rotation>
 	<joystick>8-way</joystick>
-        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin,Coin,Service,Pause"/>
+        <buttons default="A,B,Start,Select,L,R,X,Y" names="A,B,Start,Select,Coin 1,Coin 2,Service,Pause"/>
 	<switches default="00,00,FF,00,00,00,00,00">
 		<dip bits="8,9" name="Bonus Life" ids="10000,30000,50000,70000"/>
 		<dip bits="10" name="High Score Table" ids="Off,On"/>


### PR DESCRIPTION
Update the UI labels for coin inputs to improve clarity by changing them from Coin/Coin to Coin 1/Coin 2.

Currently when you map the first coin slot, the UI doesn't change so it seems like it's not being mapped.